### PR TITLE
Eliminar áreas del frontend

### DIFF
--- a/Frontend/src/components/Table/EditAreaForm.jsx
+++ b/Frontend/src/components/Table/EditAreaForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function EditAreaNameForm({ areaName, onChange, onSave, onCancel, onDelete }) {
+export default function EditAreaForm({ areaName, onChange, onSave, onCancel, onDelete }) {
 	return (
 		<div className='modal-container'>
 			<div className='overlay'>

--- a/Frontend/src/components/Table/EditAreaNameForm.jsx
+++ b/Frontend/src/components/Table/EditAreaNameForm.jsx
@@ -1,22 +1,25 @@
-import React from 'react';
+import React from 'react'
 
-export default function EditAreaNameForm({ areaName, onChange, onSave, onCancel }) {
-  return (
-    <div className="modal-container">
-      <div className="overlay">
-        <div className="modal-content">
-          <h3>Editar nombre del área</h3>
-          <input
-            value={areaName}
-            onChange={e => onChange(e.target.value)}
-            placeholder="Nuevo nombre del área"
-          />
-          <div className="modal-buttons">
-            <button onClick={onSave} className="submit-button">Guardar</button>
-            <button onClick={onCancel} className="cancel-button">Cancelar</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+export default function EditAreaNameForm({ areaName, onChange, onSave, onCancel, onDelete }) {
+	return (
+		<div className='modal-container'>
+			<div className='overlay'>
+				<div className='modal-content'>
+					<h3>Editar nombre del área</h3>
+					<input value={areaName} onChange={(e) => onChange(e.target.value)} placeholder='Nuevo nombre del área' />
+					<div className='modal-buttons'>
+						<button onClick={onSave} className='submit-button'>
+							Guardar
+						</button>
+						<button onClick={onDelete} className='delete-button'>
+							Eliminar
+						</button>
+						<button onClick={onCancel} className='cancel-button'>
+							Cancelar
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	)
 }

--- a/Frontend/src/components/Table/Table.jsx
+++ b/Frontend/src/components/Table/Table.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import EditAreaNameForm from './EditAreaNameForm'
+import EditAreaForm from './EditAreaForm'
 import EditRoleModal from './EditRoleModal'
 import RoleCell from './RoleCell'
 import './Table.css'
@@ -251,7 +251,7 @@ export function Table() {
 			)}
 
 			{/* Modal de nombre del área */}
-			{areaModal && <EditAreaNameForm areaName={areaName} onChange={setAreaName} onSave={handleSaveAreaName} onCancel={() => setAreaModal(false)} onDelete={handleDeleteArea} />}
+			{areaModal && <EditAreaForm areaName={areaName} onChange={setAreaName} onSave={handleSaveAreaName} onCancel={() => setAreaModal(false)} onDelete={handleDeleteArea} />}
 		</>
 	)
 }

--- a/Frontend/src/components/Table/Table.jsx
+++ b/Frontend/src/components/Table/Table.jsx
@@ -168,6 +168,15 @@ export function Table() {
 		}
 	}
 
+	const handleDeleteArea = () => {
+		const confirm = window.confirm(`¿Eliminar el área "${areaName}" y todos sus cargos?`)
+		if (!confirm) return
+
+		const updatedData = tableData.filter((_, i) => i !== areaIndex)
+		setTableData(updatedData)
+		setAreaModal(false)
+	}
+
 	return (
 		<>
 			<div
@@ -242,7 +251,7 @@ export function Table() {
 			)}
 
 			{/* Modal de nombre del área */}
-			{areaModal && <EditAreaNameForm areaName={areaName} onChange={setAreaName} onSave={handleSaveAreaName} onCancel={() => setAreaModal(false)} />}
+			{areaModal && <EditAreaNameForm areaName={areaName} onChange={setAreaName} onSave={handleSaveAreaName} onCancel={() => setAreaModal(false)} onDelete={handleDeleteArea} />}
 		</>
 	)
 }


### PR DESCRIPTION
## Resumen

Se añadió la funcionalidad para eliminar áreas directamente desde el modal, y se renombró el componente a `EditAreaForm` para reflejar esta nueva responsabilidad.

## Cambios

- Se añadió un botón “Eliminar Área” en el modal
- Se implementó la lógica de borrado de áreas en el frontend bajo la función `handleDeleteArea`
- Se renombró el componente `EditAreaNameForm` a `EditAreaForm` por claridad

## Issue

Resolves #3 