### PR TITLE
Null area

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -47,12 +47,37 @@ app.post("/empresas", async (req, res) => {
 
     if (areasError) throw areasError;
 
-    res.status(201).json({ empresa: empresaData, areas: areasData });
+    const totalAreas = areas.length;
+    console.log("🔧 Total de áreas:", totalAreas);
+
+    const { error: updateError } = await supabaseAdmin
+      .from("empresas")
+      .update({ areas: totalAreas })
+      .eq("id", empresa_id);
+
+    if (updateError) {
+      console.error("❌ Error al actualizar campo 'areas' en empresa:", updateError);
+      throw updateError;
+    }
+
+    console.log("✅ Campo 'areas' actualizado correctamente en la empresa.");
+
+    // 🔁 Refetch empresa ya actualizada
+    const { data: updatedEmpresa, error: fetchUpdatedError } = await supabaseAdmin
+      .from("empresas")
+      .select("*")
+      .eq("id", empresa_id)
+      .single();
+
+    if (fetchUpdatedError) throw fetchUpdatedError;
+
+    res.status(201).json({ empresa: updatedEmpresa, areas: areasData });
   } catch (error) {
     console.error("❌ Error al crear empresa y áreas:", error);
     res.status(500).json({ error: "Error al crear empresa", detalle: error.message });
   }
 });
+
 
 // Obtener todas las empresas
 app.get("/empresas", async (req, res) => {

--- a/Frontend/src/screen/AreasForm/areas_form.jsx
+++ b/Frontend/src/screen/AreasForm/areas_form.jsx
@@ -71,7 +71,9 @@ export function AreasForm() {
       const data = await res.json();
       console.log("✅ Empresa creada con áreas:", data);
 
-      navigate("/datos_prueba", { state: { empresaId: data.empresa.id } });
+     const areaNames = Object.values(formData);
+
+    navigate("/datos_prueba", { state: { areas: areaNames } });
 
     } catch (err) {
       console.error("❌ Error en la petición:", err);


### PR DESCRIPTION
Se solucionó el problema que causaba que la columna areas en la tabla empresas permaneciera en null al crear una nueva empresa. Para ello, se realizaron los siguientes ajustes:

Se verificó que la columna areas existiera correctamente en la tabla, con nombre en minúsculas y tipo integer.

Se añadió una actualización (update) en el backend para registrar el total de áreas inmediatamente después de insertarlas.

Se actualizó la lógica del frontend para transformar el objeto de áreas en un arreglo de strings usando Object.values, ya que el backend esperaba un array.

Se implementó una consulta adicional después del update para devolver la empresa con el campo areas actualizado en la respuesta.

Se agregaron console.log para depurar y verificar que la información llegara correctamente y que el flujo funcionara como se esperaba.

Fixes #54