### PR TITLE
Style(tooltip): Ajuste de ancho tooltop jerarquias

### DIFF
--- a/Frontend/src/components/Table/Table.css
+++ b/Frontend/src/components/Table/Table.css
@@ -3,7 +3,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-   align-items: center;
+	align-items: center;
 	padding: 20px 0;
 }
 
@@ -52,6 +52,7 @@ td {
 	border-radius: 30px;
 	border: 8px solid white;
 	padding: 4px 32px;
+	font-weight: 400;
 }
 
 .jerarquia div {
@@ -64,6 +65,10 @@ td {
 .jerarquia p {
 	font-size: 38px;
 	font-weight: 100;
+}
+
+.tooltip-jerarquia .popuptext {
+	width: 14rem;
 }
 
 td button {
@@ -336,15 +341,16 @@ td span .role-name {
 	margin: 0;
 }
 
-.empty-role{
-   font-size: 1rem;
-   font-weight: normal;
-   display: flex;
-   justify-content: center;
-   align-items: center;
-   gap: 10px;
+.empty-role {
+	font-size: 1rem;
+	font-weight: normal;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: 10px;
 }
-.empty-role p:last-child{
-   font-size: 1rem;
-   font-weight: 500;
+
+.empty-role p:last-child {
+	font-size: 1rem;
+	font-weight: 500;
 }

--- a/Frontend/src/components/Table/Table.jsx
+++ b/Frontend/src/components/Table/Table.jsx
@@ -245,7 +245,7 @@ export function Table() {
 							<th />
 							{jerarquias.map((j) => (
 								<th key={j} className='jerarquia'>
-									<div>
+									<div className='tooltip-jerarquia'>
 										<p>{j}</p>
 										<Tooltip triggerText={<img src={jerarquiaIcons[j]} alt={j} width={40} />} popupText={nivelesJerarquia[j]} />
 									</div>


### PR DESCRIPTION
- Se aplicó una clase externa `.tooltip-jerarquia` para modificar el ancho del popup de Tooltip solo en la tabla de jerarquías. Esto evita afectar los tooltips globales y mantiene el componente reutilizable sin modificaciones internas.

Closes #86